### PR TITLE
Add simplified node storage space alert metric

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -204,6 +204,7 @@ metrics_reporter::build_metrics_snapshot() {
           });
 
         metrics.uptime_ms = report.local_state.uptime / 1ms;
+        metrics.storage_space_alert = report.local_state.storage_space_alert;
     }
     auto& topics = _topics.local().topics_map();
     snapshot.topic_count = 0;
@@ -416,6 +417,8 @@ void rjson_serialize(
         rjson_serialize(w, d);
     }
     w.EndArray();
+    w.Key("storage_space_alert");
+    w.Uint(static_cast<uint32_t>(nm.storage_space_alert));
 
     w.EndObject();
 }

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -58,6 +58,7 @@ public:
         ss::sstring version;
         std::vector<node_disk_space> disks;
         uint64_t uptime_ms;
+        node::disk_space_alert storage_space_alert;
     };
 
     struct metrics_snapshot {

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -80,7 +80,7 @@ ss::future<struct statvfs> local_monitor::get_statvfs(const ss::sstring& path) {
 }
 
 void local_monitor::update_alert_state() {
-    _state.storage_space_alert = 0;
+    _state.storage_space_alert = disk_space_alert::ok;
     for (const auto& d : _state.disks) {
         vassert(d.total != 0.0, "Total disk space cannot be zero.");
         double min_space = double(d.total) * alert_min_free_space_percent;
@@ -94,7 +94,7 @@ void local_monitor::update_alert_state() {
           double(d.free) <= min_space);
 
         if (double(d.free) <= min_space) {
-            _state.storage_space_alert = 1;
+            _state.storage_space_alert = disk_space_alert::low_space;
         }
     }
 }

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/node/local_monitor.h"
 
+#include "cluster/logger.h"
 #include "cluster/node/types.h"
 #include "config/node_config.h"
 #include "model/timestamp.h"
@@ -22,6 +23,8 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sstring.hh>
 
+#include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <seastarx.h>
 
@@ -38,6 +41,7 @@ ss::future<> local_monitor::update_state() {
       .uptime = uptime,
       .disks = disks,
     };
+    update_alert_state();
     co_return;
 }
 
@@ -74,4 +78,25 @@ ss::future<struct statvfs> local_monitor::get_statvfs(const ss::sstring& path) {
         co_return co_await ss::engine().statvfs(path);
     }
 }
+
+void local_monitor::update_alert_state() {
+    _state.storage_space_alert = 0;
+    for (const auto& d : _state.disks) {
+        vassert(d.total != 0.0, "Total disk space cannot be zero.");
+        double min_space = double(d.total) * alert_min_free_space_percent;
+        min_space = std::min(min_space, alert_min_free_space_bytes);
+        clusterlog.debug(
+          "{}: min by % {}, min bytes {}, disk.free {} -> alert {}",
+          __func__,
+          double(d.total) * alert_min_free_space_percent,
+          alert_min_free_space_bytes,
+          d.free,
+          double(d.free) <= min_space);
+
+        if (double(d.free) <= min_space) {
+            _state.storage_space_alert = 1;
+        }
+    }
+}
+
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -47,12 +47,17 @@ void local_monitor::set_path_for_test(const ss::sstring& path) {
     _path_for_test = path;
 }
 
+void local_monitor::set_statvfs_for_test(
+  std::function<struct statvfs(const ss::sstring&)> func) {
+    _statvfs_for_test = std::move(func);
+}
+
 ss::future<std::vector<disk>> local_monitor::get_disks() {
     auto path = _path_for_test.empty()
                   ? config::node().data_directory().as_sstring()
                   : _path_for_test;
 
-    auto svfs = co_await ss::engine().statvfs(path);
+    auto svfs = co_await get_statvfs(path);
 
     co_return std::vector<disk>{disk{
       .path = config::node().data_directory().as_sstring(),
@@ -62,4 +67,11 @@ ss::future<std::vector<disk>> local_monitor::get_disks() {
     }};
 }
 
+ss::future<struct statvfs> local_monitor::get_statvfs(const ss::sstring& path) {
+    if (_statvfs_for_test) {
+        co_return _statvfs_for_test.value()(path);
+    } else {
+        co_return co_await ss::engine().statvfs(path);
+    }
+}
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -13,6 +13,7 @@
 
 #include "cluster/logger.h"
 #include "cluster/node/types.h"
+#include "config/configuration.h"
 #include "config/node_config.h"
 #include "model/timestamp.h"
 #include "version.h"
@@ -31,6 +32,9 @@
 namespace cluster::node {
 
 ss::future<> local_monitor::update_state() {
+    refresh_configuration();
+
+    // grab new snapshot of local state
     auto disks = co_await get_disks();
     auto vers = application_version(ss::sstring(redpanda_version()));
     auto uptime = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -54,6 +58,13 @@ void local_monitor::set_path_for_test(const ss::sstring& path) {
 void local_monitor::set_statvfs_for_test(
   std::function<struct statvfs(const ss::sstring&)> func) {
     _statvfs_for_test = std::move(func);
+}
+
+std::tuple<size_t, size_t>
+local_monitor::minimum_free_by_bytes_and_percent(size_t bytes_available) {
+    long double percent_factor = last_free_space_percent_threshold / 100.0;
+    return std::make_tuple(
+      last_free_space_bytes_threshold, percent_factor * bytes_available);
 }
 
 ss::future<std::vector<disk>> local_monitor::get_disks() {
@@ -83,20 +94,68 @@ void local_monitor::update_alert_state() {
     _state.storage_space_alert = disk_space_alert::ok;
     for (const auto& d : _state.disks) {
         vassert(d.total != 0.0, "Total disk space cannot be zero.");
-        double min_space = double(d.total) * alert_min_free_space_percent;
-        min_space = std::min(min_space, alert_min_free_space_bytes);
+        auto [min_by_bytes, min_by_percent] = minimum_free_by_bytes_and_percent(
+          d.total);
+        auto min_space = std::min(min_by_percent, min_by_bytes);
         clusterlog.debug(
-          "{}: min by % {}, min bytes {}, disk.free {} -> alert {}",
-          __func__,
-          double(d.total) * alert_min_free_space_percent,
-          alert_min_free_space_bytes,
+          "min by % {}, min bytes {}, disk.free {} -> alert {}",
+          min_by_percent,
+          min_by_bytes,
           d.free,
-          double(d.free) <= min_space);
+          d.free <= min_space);
 
-        if (double(d.free) <= min_space) {
+        if (d.free <= min_space) {
             _state.storage_space_alert = disk_space_alert::low_space;
         }
     }
+}
+
+void local_monitor::refresh_configuration() {
+    auto percent_threshold = get_config_alert_threshold_percent();
+    auto bytes_threshold = get_config_alert_threshold_bytes();
+    // TODO replace with bounded config feature
+    if (percent_threshold > max_percent_free_threshold) {
+        clusterlog.warn(
+          "Configuration value {} for "
+          "storage_space_alert_free_threshold_percent exceeds "
+          "maximum, using {}.",
+          percent_threshold,
+          max_percent_free_threshold);
+        percent_threshold = max_percent_free_threshold;
+    }
+    if (bytes_threshold > max_bytes_free_threshold) {
+        clusterlog.warn(
+          "Configuration value {} for "
+          "storage_space_alert_free_threshold_bytes exceeds "
+          "maximum, using {}.",
+          bytes_threshold,
+          max_bytes_free_threshold);
+        bytes_threshold = max_bytes_free_threshold;
+    }
+    if (last_free_space_percent_threshold != percent_threshold) {
+        clusterlog.info(
+          "Updated free space percent alert threshold {} -> {}",
+          last_free_space_percent_threshold,
+          percent_threshold);
+        last_free_space_percent_threshold = percent_threshold;
+    }
+
+    if (last_free_space_bytes_threshold != bytes_threshold) {
+        clusterlog.info(
+          "Updated free space bytes alert threshold {} -> {}",
+          last_free_space_bytes_threshold,
+          bytes_threshold);
+        last_free_space_bytes_threshold = bytes_threshold;
+    }
+}
+
+std::size_t local_monitor::get_config_alert_threshold_bytes() {
+    return config::shard_local_cfg().storage_space_alert_free_threshold_bytes();
+}
+
+unsigned local_monitor::get_config_alert_threshold_percent() {
+    return config::shard_local_cfg()
+      .storage_space_alert_free_threshold_percent();
 }
 
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -43,9 +43,16 @@ ss::future<> local_monitor::update_state() {
 
 const local_state& local_monitor::get_state_cached() const { return _state; }
 
+void local_monitor::set_path_for_test(const ss::sstring& path) {
+    _path_for_test = path;
+}
+
 ss::future<std::vector<disk>> local_monitor::get_disks() {
-    auto svfs = co_await ss::engine().statvfs(
-      config::node().data_directory().as_sstring());
+    auto path = _path_for_test.empty()
+                  ? config::node().data_directory().as_sstring()
+                  : _path_for_test;
+
+    auto svfs = co_await ss::engine().statvfs(path);
 
     co_return std::vector<disk>{disk{
       .path = config::node().data_directory().as_sstring(),

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -32,20 +32,29 @@ public:
     ss::future<> update_state();
     const local_state& get_state_cached() const;
 
-    // Visible for test...
-    static constexpr double alert_min_free_space_percent = 0.05;
-    static constexpr double alert_min_free_space_bytes = 1_GiB;
+    // Visible for test
+    static constexpr int max_percent_free_threshold = 50;
+    static constexpr size_t max_bytes_free_threshold = 1_TiB;
 
     void set_path_for_test(const ss::sstring& path);
     void
       set_statvfs_for_test(std::function<struct statvfs(const ss::sstring&)>);
+    std::tuple<size_t, size_t>
+    minimum_free_by_bytes_and_percent(size_t bytes_available);
 
 private:
     ss::future<std::vector<disk>> get_disks();
     ss::future<struct statvfs> get_statvfs(const ss::sstring&);
     void update_alert_state();
 
+    // configuration
+    void refresh_configuration();
+    std::size_t get_config_alert_threshold_bytes();
+    unsigned get_config_alert_threshold_percent();
+
     local_state _state;
+    unsigned last_free_space_percent_threshold = 0;
+    size_t last_free_space_bytes_threshold = 0;
 
     // Injection points for unit tests
     ss::sstring _path_for_test;

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -13,6 +13,8 @@
 
 #include <seastar/core/sstring.hh>
 
+#include <sys/statvfs.h>
+
 // Local node state monitoring is kept separate in case we want to access it
 // pre-quorum formation in the future, etc.
 namespace cluster::node {
@@ -30,13 +32,18 @@ public:
     const local_state& get_state_cached() const;
 
     void set_path_for_test(const ss::sstring& path);
+    void
+      set_statvfs_for_test(std::function<struct statvfs(const ss::sstring&)>);
 
 private:
     ss::future<std::vector<disk>> get_disks();
+    ss::future<struct statvfs> get_statvfs(const ss::sstring&);
     local_state _state;
 
     // Injection points for unit tests
     ss::sstring _path_for_test;
+    std::optional<std::function<struct statvfs(const ss::sstring&)>>
+      _statvfs_for_test;
 };
 
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -11,6 +11,8 @@
 #pragma once
 #include "cluster/node/types.h"
 
+#include <seastar/core/sstring.hh>
+
 // Local node state monitoring is kept separate in case we want to access it
 // pre-quorum formation in the future, etc.
 namespace cluster::node {
@@ -27,9 +29,14 @@ public:
     ss::future<> update_state();
     const local_state& get_state_cached() const;
 
+    void set_path_for_test(const ss::sstring& path);
+
 private:
-    static ss::future<std::vector<disk>> get_disks();
+    ss::future<std::vector<disk>> get_disks();
     local_state _state;
+
+    // Injection points for unit tests
+    ss::sstring _path_for_test;
 };
 
 } // namespace cluster::node

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "cluster/node/types.h"
+#include "units.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -31,6 +32,10 @@ public:
     ss::future<> update_state();
     const local_state& get_state_cached() const;
 
+    // Visible for test...
+    static constexpr double alert_min_free_space_percent = 0.05;
+    static constexpr double alert_min_free_space_bytes = 1_GiB;
+
     void set_path_for_test(const ss::sstring& path);
     void
       set_statvfs_for_test(std::function<struct statvfs(const ss::sstring&)>);
@@ -38,6 +43,8 @@ public:
 private:
     ss::future<std::vector<disk>> get_disks();
     ss::future<struct statvfs> get_statvfs(const ss::sstring&);
+    void update_alert_state();
+
     local_state _state;
 
     // Injection points for unit tests

--- a/src/v/cluster/node/types.cc
+++ b/src/v/cluster/node/types.cc
@@ -30,6 +30,21 @@ std::ostream& operator<<(std::ostream& o, const disk& d) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const disk_space_alert d) {
+    switch (d) {
+    case disk_space_alert::ok:
+        o << "ok";
+        break;
+    case disk_space_alert::low_space:
+        o << "low_space";
+        break;
+    case disk_space_alert::degraded:
+        o << "degraded";
+        break;
+    }
+    return o;
+}
+
 std::ostream& operator<<(std::ostream& o, const local_state& s) {
     fmt::print(
       o,

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -49,6 +49,8 @@ struct local_state {
     std::chrono::milliseconds uptime;
     // Eventually support multiple volumes.
     std::vector<disk> disks;
+    // TODO distinct type instead of int
+    unsigned storage_space_alert;
 
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -41,6 +41,8 @@ struct disk {
     friend bool operator==(const disk&, const disk&) = default;
 };
 
+enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
+
 /**
  * A snapshot of node-local state: i.e. things that don't depend on consensus.
  */
@@ -49,13 +51,14 @@ struct local_state {
     std::chrono::milliseconds uptime;
     // Eventually support multiple volumes.
     std::vector<disk> disks;
-    // TODO distinct type instead of int
-    unsigned storage_space_alert;
+
+    disk_space_alert storage_space_alert;
 
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };
 
 std::ostream& operator<<(std::ostream& o, const disk& d);
+std::ostream& operator<<(std::ostream& o, const disk_space_alert d);
 std::ostream& operator<<(std::ostream& o, const local_state& s);
 } // namespace cluster::node
 

--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -20,6 +20,8 @@
 
 #include <fmt/ostream.h>
 
+#include <cstdint>
+
 namespace cluster::node {
 
 //
@@ -41,7 +43,7 @@ struct disk {
     friend bool operator==(const disk&, const disk&) = default;
 };
 
-enum class disk_space_alert { ok = 0, low_space = 1, degraded = 2 };
+enum class disk_space_alert : uint32_t { ok = 0, low_space = 1, degraded = 2 };
 
 /**
  * A snapshot of node-local state: i.e. things that don't depend on consensus.

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -40,7 +40,9 @@ set(srcs
     id_allocator_stm_test.cc
     data_policy_controller_test.cc
     health_monitor_test.cc
-    topic_configuration_compat_test.cc)
+    topic_configuration_compat_test.cc
+    local_monitor_test.cc)
+
 
 rp_test(
   UNIT_TEST

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -24,10 +24,14 @@ struct local_monitor_fixture {
     local_monitor_fixture& operator=(local_monitor_fixture&&) = default;
     ~local_monitor_fixture();
 
+    static constexpr unsigned default_percent_threshold = 5;
+    static constexpr size_t default_bytes_threshold = 1_GiB;
+
     std::filesystem::path _test_path;
     cluster::node::local_monitor _local_monitor;
 
     cluster::node::local_state update_state();
     static struct statvfs make_statvfs(
       unsigned long blk_free, unsigned long blk_total, unsigned long blk_size);
+    void set_config_alert_thresholds(unsigned percent, size_t bytes);
 };

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -28,4 +28,6 @@ struct local_monitor_fixture {
     cluster::node::local_monitor _local_monitor;
 
     cluster::node::local_state update_state();
+    static struct statvfs make_statvfs(
+      unsigned long blk_free, unsigned long blk_total, unsigned long blk_size);
 };

--- a/src/v/cluster/tests/local_monitor_fixture.h
+++ b/src/v/cluster/tests/local_monitor_fixture.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/node/local_monitor.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <string_view>
+
+struct local_monitor_fixture {
+    local_monitor_fixture();
+    local_monitor_fixture(const local_monitor_fixture&) = delete;
+    local_monitor_fixture(local_monitor_fixture&&) = default;
+    local_monitor_fixture& operator=(const local_monitor_fixture&) = delete;
+    local_monitor_fixture& operator=(local_monitor_fixture&&) = default;
+    ~local_monitor_fixture();
+
+    std::filesystem::path _test_path;
+    cluster::node::local_monitor _local_monitor;
+
+    cluster::node::local_state update_state();
+};

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -99,12 +99,14 @@ FIXTURE_TEST(local_monitor_alert_on_space_percent, local_monitor_fixture) {
     // One block over the threshold should not alert
     stats.f_bfree = min_free_percent_blocks + 1;
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert == 0);
+    BOOST_TEST_REQUIRE(
+      ls.storage_space_alert == cluster::node::disk_space_alert::ok);
 
     // One block under the free threshold should alert
     stats.f_bfree = min_free_percent_blocks - 1;
     ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert != 0);
+    BOOST_TEST_REQUIRE(
+      ls.storage_space_alert != cluster::node::disk_space_alert::ok);
 }
 
 FIXTURE_TEST(local_monitor_alert_on_space_bytes, local_monitor_fixture) {
@@ -124,10 +126,12 @@ FIXTURE_TEST(local_monitor_alert_on_space_bytes, local_monitor_fixture) {
     _local_monitor.set_statvfs_for_test(lamb);
 
     auto ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert == 0);
+    BOOST_TEST_REQUIRE(
+      ls.storage_space_alert == cluster::node::disk_space_alert::ok);
 
     // Min bytes threshold minus a blocks -> Alert
     stats.f_bfree = min_bytes_in_blocks - 1;
     ls = update_state();
-    BOOST_TEST_REQUIRE(ls.storage_space_alert != 0);
+    BOOST_TEST_REQUIRE(
+      ls.storage_space_alert != cluster::node::disk_space_alert::ok);
 }

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "local_monitor_fixture.h"
+#include "redpanda/tests/fixture.h"
+#include "seastarx.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/interface.hpp>
+#include <fmt/format.h>
+
+#include <filesystem>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+inline ss::logger logger(__FILE__); // NOLINT static may throw
+
+local_monitor_fixture::local_monitor_fixture() {
+    logger.info("{}: create", __func__);
+    auto test_dir = "local_monitor_test."
+                    + random_generators::gen_alphanum_string(4);
+
+    _test_path = std::filesystem::absolute(test_dir.c_str());
+
+    std::error_code errc;
+    std::filesystem::create_directory(_test_path, errc);
+    if (errc) {
+        logger.warn(
+          "{}: failed to create test dir {}: {}", __func__, _test_path, errc);
+    } else {
+        logger.info("{}: created test dir {}", __func__, _test_path);
+    }
+    _local_monitor.set_path_for_test(_test_path.string());
+    BOOST_ASSERT(ss::engine_is_ready());
+}
+
+local_monitor_fixture::~local_monitor_fixture() {
+    logger.info("{}: destroy", __func__);
+    std::error_code err;
+    std::filesystem::remove_all(std::filesystem::path(_test_path), err);
+    if (err) {
+        logger.warn("Cleanup got error {} removing test dir.", err);
+    }
+}
+
+cluster::node::local_state local_monitor_fixture::update_state() {
+    _local_monitor.update_state()
+      .then([&]() { logger.info("Updated local state."); })
+      .get();
+    return _local_monitor.get_state_cached();
+}
+
+FIXTURE_TEST(local_state_has_single_disk, local_monitor_fixture) {
+    auto ls = update_state();
+    BOOST_TEST_REQUIRE(ls.disks.size() == 1);
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1002,6 +1002,20 @@ configuration::configuration()
       "Max age of metadata cached in the health monitor of non controller node",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
+  , storage_space_alert_free_threshold_percent(
+      *this,
+      "storage_space_alert_free_threshold_percent",
+      "Threshold of minimim percent free space before setting storage space "
+      "alert",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5)
+  , storage_space_alert_free_threshold_bytes(
+      *this,
+      "storage_space_alert_free_threshold_bytes",
+      "Threshold of minimim bytes free space before setting storage space "
+      "alert",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1_GiB)
   , enable_metrics_reporter(
       *this,
       "enable_metrics_reporter",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -228,6 +228,8 @@ struct configuration final : public config_store {
     // health monitor
     property<std::chrono::milliseconds> health_monitor_tick_interval;
     property<std::chrono::milliseconds> health_monitor_max_metadata_age;
+    property<unsigned> storage_space_alert_free_threshold_percent;
+    property<size_t> storage_space_alert_free_threshold_bytes;
     // metrics reporter
     property<bool> enable_metrics_reporter;
     property<std::chrono::milliseconds> metrics_reporter_tick_interval;

--- a/src/v/units.h
+++ b/src/v/units.h
@@ -18,7 +18,9 @@
 constexpr size_t KiB = 1024;
 constexpr size_t MiB = 1024 * KiB;
 constexpr size_t GiB = 1024 * MiB;
+constexpr size_t TiB = 1024 * GiB;
 
 constexpr size_t operator"" _KiB(unsigned long long val) { return val * KiB; }
 constexpr size_t operator"" _MiB(unsigned long long val) { return val * MiB; }
 constexpr size_t operator"" _GiB(unsigned long long val) { return val * GiB; }
+constexpr size_t operator"" _TiB(unsigned long long val) { return val * TiB; }

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -89,6 +89,7 @@ class MetricsReporterTest(RedpandaTest):
         assert all('uptime_ms' in n for n in nodes_meta)
         assert all('is_alive' in n for n in nodes_meta)
         assert all('disks' in n for n in nodes_meta)
+        assert all('storage_space_alert' in n for n in nodes_meta)
 
         # Check cluster UUID and creation time survive a restart
         for n in self.redpanda.nodes:


### PR DESCRIPTION
Currently, alerting on running out of disk space on a node depends only on external monitoring pulling both the total and available bytes of storage and alerting on that. To allow us to also emit periodic log messages, and expose a simplified metric (think "Check Engine" light on your car), this PR adds a new metric to `metrics_reporter` which is zero if we have sufficient space, and non-zero when space is getting dangerously low.

Next steps will be:
- Make thresholds configurable (patch coming).
- Block writers to kafka namespace (external topics), surfacing errors to clients, when space becomes critical.

Note the clock injection for test was to be used for a simple linear "time left before storage exhaustion" threshold that could also trigger the alert, but there is some disagreement whether or not this belongs inside RP.